### PR TITLE
[HIS-5925] Add future features to 6.2: snapshot options and cancel

### DIFF
--- a/bindings/go/src/fdb/snapshot.go
+++ b/bindings/go/src/fdb/snapshot.go
@@ -96,5 +96,5 @@ func (s Snapshot) GetDatabase() Database {
 // Snapshot returns the receiver and allows Snapshot to satisfy the
 // ReadTransaction interface.
 func (s Snapshot) Options() TransactionOptions {
-	return s.Options()
+	return TransactionOptions{s.transaction}
 }

--- a/bindings/go/src/fdb/snapshot.go
+++ b/bindings/go/src/fdb/snapshot.go
@@ -53,6 +53,12 @@ func (s Snapshot) ReadTransact(f func(ReadTransaction) (interface{}, error)) (r 
 	return
 }
 
+// Cancel cancels the underlying transaction of the snapshot.
+// See Transaction.Cancel() for more information.
+func (s Snapshot) Cancel() {
+	s.transaction.cancel()
+}
+
 // Snapshot returns the receiver and allows Snapshot to satisfy the
 // ReadTransaction interface.
 func (s Snapshot) Snapshot() Snapshot {
@@ -85,4 +91,10 @@ func (s Snapshot) GetReadVersion() FutureInt64 {
 // interacting.
 func (s Snapshot) GetDatabase() Database {
 	return s.transaction.db
+}
+
+// Snapshot returns the receiver and allows Snapshot to satisfy the
+// ReadTransaction interface.
+func (s Snapshot) Options() TransactionOptions {
+	return s.Options()
 }

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -88,6 +88,10 @@ func (t *transaction) destroy() {
 	C.fdb_transaction_destroy(t.ptr)
 }
 
+func (t *transaction) cancel() {
+	C.fdb_transaction_cancel(t.ptr)
+}
+
 // GetDatabase returns a handle to the database with which this transaction is
 // interacting.
 func (t Transaction) GetDatabase() Database {


### PR DESCRIPTION
I need those two methods to be able to cancel and timeout snapshot queries properly.
I copied the code from the most recent version of the bindings in the apple repo https://github.com/apple/foundationdb/blob/main/bindings/go/src/fdb/snapshot.go

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
